### PR TITLE
Added a replace function to remove any trailing slashes on the prefix.

### DIFF
--- a/asset.js
+++ b/asset.js
@@ -7,5 +7,5 @@ export const asset = (path) => {
         prefix = document.head.querySelector('meta[name="asset-url"]').content
     }
 
-    return prefix + '/' + path.replace(/^\/+/, '')
+    return prefix.replace(/\/+$/, '') + '/' + path.replace(/^\/+/, '')
 }


### PR DESCRIPTION
I need this addition to prevent any accidental trailing slashes in the prefix variable.
I might use this package this way:
``` Js
<meta name="asset-url" content="{{ asset('') }}">
```
and the `asset()` helper function from Laravel generates a trailing slash (a slash at the end of the url).